### PR TITLE
Add Theatre.js to visual editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A-Frame Boilerplates:
 - [Needle Engine](https://needle.tools/) ![][threejs-badge] ![][unity-badge]
 - [react-three-editor](https://github.com/pmndrs/react-three-editor) ![][r3f-badge]
 - [Babylon.js Editor](https://editor.babylonjs.com/)  ![][babylon-badge]
+- [Theatre.js](https://www.theatrejs.com/) ![][threejs-badge] ![][r3f-badge]
 
 ## State Management
 


### PR DESCRIPTION
Hi, I wanted to add Theatre.js to the list of visual editors. Most of its users are using it as a visual editor now, than an animation editor.